### PR TITLE
feat!: Switch to streamx

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Wrap a ReadableStream in a TransformStream.
 ## Usage
 
 ```js
-var from = require('from2');
+var streamx = require('streamx');
 var concat = require('concat-stream');
 var toThrough = require('to-through');
 
+var from = streamx.Readable.from;
 var readable = from([' ', 'hello', ' ', 'world']);
 
 // Can be used as a Readable or Transform
@@ -35,7 +36,8 @@ from(['hi', ' ', 'there', ','])
 
 ### `toThrough(readableStream)`
 
-Takes a `readableStream` as the only argument and returns a `through2` stream. If the returned stream is piped before `nextTick`, the wrapped `readableStream` will not flow until the upstream is flushed. If the stream is not piped before `nextTick`, it is ended and flushed (acting as a proper readable).
+Takes a `readableStream` as the only argument and returns a wrapper stream.  Any data
+piped into the wrapper before the wrapper is piped out will flush before `readableStream`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][ci-image]][ci-url] [![Coveralls Status][coveralls-image]][coveralls-url]
 
-Wrap a ReadableStream in a TransformStream.
+Wrap a `Readable` stream in a `Transform` stream.
 
 ## Usage
 
@@ -35,8 +35,8 @@ Readable.from(['hi', ' ', 'there', ','])
 
 ### `toThrough(readableStream)`
 
-Takes a `readableStream` as the only argument and returns a wrapper stream. Any data
-piped into the wrapper before the wrapper is piped out will flush before `readableStream`.
+Takes a `Readable` stream as the only argument and returns a `Transform` stream wrapper. Any data
+piped into the `Transform` stream is piped passed along before any data from the wrapped `Readable` is injected into the stream.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Readable.from(['hi', ' ', 'there', ','])
   .pipe(maybeTransform)
   .pipe(
     concat(function (result) {
-      // result.toString() === 'hi there, hello world'
+      // result === 'hi there, hello world'
     })
   );
 ```

--- a/README.md
+++ b/README.md
@@ -13,17 +13,16 @@ Wrap a ReadableStream in a TransformStream.
 ## Usage
 
 ```js
-var streamx = require('streamx');
+var { Readable } = require('streamx');
 var concat = require('concat-stream');
 var toThrough = require('to-through');
 
-var from = streamx.Readable.from;
-var readable = from([' ', 'hello', ' ', 'world']);
+var readable = Readable.from([' ', 'hello', ' ', 'world']);
 
 // Can be used as a Readable or Transform
 var maybeTransform = toThrough(readable);
 
-from(['hi', ' ', 'there', ','])
+Readable.from(['hi', ' ', 'there', ','])
   .pipe(maybeTransform)
   .pipe(
     concat(function (result) {
@@ -36,7 +35,7 @@ from(['hi', ' ', 'there', ','])
 
 ### `toThrough(readableStream)`
 
-Takes a `readableStream` as the only argument and returns a wrapper stream.  Any data
+Takes a `readableStream` as the only argument and returns a wrapper stream. Any data
 piped into the wrapper before the wrapper is piped out will flush before `readableStream`.
 
 ## License

--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ function toThrough(readable) {
     }
 
     function onRead(chunk) {
-      self.push(chunk);
       cleanup();
+      self.push(chunk);
       cb();
     }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ function toThrough(readable) {
     var self = this;
 
     readable.on('readable', onReadable);
+    // TODO: Need to cleanup
     readable.on('end', cb);
+    readable.on('error', cb);
 
     function onReadable() {
       var chunk;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "to-through",
   "version": "2.0.0",
-  "description": "Wrap a ReadableStream in a TransformStream.",
+  "description": "Wrap a Readable stream in a Transform stream.",
   "author": "Gulp Team <team@gulpjs.com> (https://gulpjs.com/)",
   "contributors": [
     "Blaine Bublitz <blaine.bublitz@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "streamx": "^2.10.0"
+    "streamx": "^2.12.5"
   },
   "devDependencies": {
     "eslint": "^7.32.0",
@@ -30,7 +30,8 @@
     "eslint-plugin-node": "^11.1.0",
     "expect": "^27.4.2",
     "mocha": "^8.4.0",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "readable-stream": "^3.6.0"
   },
   "nyc": {
     "reporter": [

--- a/package.json
+++ b/package.json
@@ -22,14 +22,13 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "through2": "^2.0.3"
+    "streamx": "^2.10.0"
   },
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-gulp": "^5.0.1",
     "eslint-plugin-node": "^11.1.0",
     "expect": "^27.4.2",
-    "mississippi": "^4.0.0",
     "mocha": "^8.4.0",
     "nyc": "^15.1.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -284,7 +284,7 @@ function suite(moduleName) {
       this.timeout(10000);
 
       var readable = stream.Readable.from(contents, {
-        highWaterMark: 1,
+        highWaterMark: moduleName === 'streamx' ? 1024 : 1,
       });
 
       function assert(result) {
@@ -305,6 +305,27 @@ function suite(moduleName) {
       this.timeout(10000);
 
       var readable = stream.Readable.from(contents);
+
+      function assert(result) {
+        expect(result).toEqual(preContents.concat(contents));
+      }
+
+      stream.pipeline(
+        [
+          stream.Readable.from(preContents),
+          toThrough(readable),
+          concat(assert, { highWaterMark: 1, objectMode: true, timeout: 250 }),
+        ],
+        done
+      );
+    });
+
+    it('respects highWaterMark of itself and the output stream', function (done) {
+      this.timeout(10000);
+
+      var readable = stream.Readable.from(contents, {
+        highWaterMark: moduleName === 'streamx' ? 1024 : 1,
+      });
 
       function assert(result) {
         expect(result).toEqual(preContents.concat(contents));

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ function suite(moduleName) {
     return new stream.Writable(
       Object.assign({}, opts, {
         write: function (data, enc, cb) {
+          console.log('write called', data);
           if (typeof enc === 'function') {
             cb = enc;
           }
@@ -232,6 +233,46 @@ function suite(moduleName) {
           stream.Readable.from(preContents),
           toThrough(readable),
           concat(assert, { objectMode: true }),
+        ],
+        done
+      );
+    });
+
+    it('inherits the highWaterMark of the wrapped stream', function (done) {
+      this.timeout(10000);
+
+      var readable = stream.Readable.from(contents, {
+        highWaterMark: 1,
+      });
+
+      function assert(result) {
+        expect(result).toEqual(preContents.concat(contents));
+      }
+
+      stream.pipeline(
+        [
+          stream.Readable.from(preContents),
+          toThrough(readable),
+          concat(assert, { objectMode: true, timeout: 250 }),
+        ],
+        done
+      );
+    });
+
+    it('respects highWaterMark of the output stream', function (done) {
+      this.timeout(10000);
+
+      var readable = stream.Readable.from(contents);
+
+      function assert(result) {
+        expect(result).toEqual(preContents.concat(contents));
+      }
+
+      stream.pipeline(
+        [
+          stream.Readable.from(preContents),
+          toThrough(readable),
+          concat(assert, { highWaterMark: 1, objectMode: true, timeout: 250 }),
         ],
         done
       );

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var expect = require('expect');
-var stream = require('stream');
+var stream = require('readable-stream');
 var streamx = require('streamx');
 var concatStream = require('concat-stream');
 
@@ -16,7 +16,7 @@ function streamxConcat(callback) {
       cb();
     },
 
-    destroy: function () {
+    flush: function () {
       if (callback) {
         if (results.length > 0 && typeof results[0] === 'string') {
           results.toString = function () {
@@ -196,3 +196,11 @@ describe('stream.pipeline with stream.Readable, streamxConcat', testRunner(strea
 
 describe('stream.pipeline with streamx.Readable, concatStream', testRunner(stream.pipeline, streamx.Readable, concatStream));
 describe('stream.pipeline with streamx.Readable, streamxConcat', testRunner(stream.pipeline, streamx.Readable, streamxConcat));
+
+/* Disabled until streamx.pipeline callback is working
+describe('streamx.pipeline with stream.Readable, concatStream', testRunner(streamx.pipeline, stream.Readable, concatStream));
+describe('streamx.pipeline with stream.Readable, streamxConcat', testRunner(streamx.pipeline, stream.Readable, streamxConcat));
+
+describe('streamx.pipeline with streamx.Readable, concatStream', testRunner(streamx.pipeline, streamx.Readable, concatStream));
+describe('streamx.pipeline with streamx.Readable, streamxConcat', testRunner(streamx.pipeline, streamx.Readable, streamxConcat));
+ */

--- a/test/index.js
+++ b/test/index.js
@@ -217,6 +217,19 @@ function suite(moduleName) {
 
       wrapped.destroy();
     });
+
+    it('destroys the wrapper if the readable is destroyed', function (done) {
+      var readable = stream.Readable.from(contents, { objectMode: false });
+
+      var wrapped = toThrough(readable);
+
+      wrapped.on('close', function () {
+        expect(wrapped.destroyed).toEqual(true);
+        done();
+      });
+
+      readable.destroy();
+    });
   });
 
   describe('object mode (' + moduleName + ')', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -1,145 +1,198 @@
 'use strict';
 
 var expect = require('expect');
-
-var miss = require('mississippi');
+var stream = require('stream');
+var streamx = require('streamx');
+var concatStream = require('concat-stream');
 
 var toThrough = require('../');
 
-var from = miss.from;
-var pipe = miss.pipe;
-var concat = miss.concat;
+function streamxConcat(callback) {
+  var results = [];
 
-describe('toThrough (buffer mode)', function () {
-  // These tests ensure it automatically detects buffer mode
+  return new streamx.Writable({
+    write: function (data, cb) {
+      results.push(data);
+      cb();
+    },
 
-  var preContents = ['from', ' ', 'upstream', ' '];
-  var contents = ['hello', ' ', 'world', ' ', '123'];
+    destroy: function () {
+      if (callback) {
+        if (results.length > 0 && typeof results[0] === 'string') {
+          results.toString = function () {
+            return results.join('');
+          };
+        }
 
-  it('can wrap a Readable and be used as a Readable', function (done) {
-    var readable = from(contents);
-
-    function assert(result) {
-      expect(result.toString()).toEqual(contents.join(''));
+        callback(results);
+      }
     }
-
-    pipe([toThrough(readable), concat(assert)], done);
   });
+}
 
-  it('can wrap a Readable and be used as a Transform', function (done) {
-    var readable = from(contents);
+function testRunner (pipeline, Readable, concat) {
+  var from = Readable.from;
+  var fromObj = function (contents) {
+    return from(contents, {objectMode: true});
+  };
 
-    function assert(result) {
-      expect(result.toString()).toEqual(contents.join(''));
-    }
+  return function () {
+    describe('buffered', function () {
+      // These tests ensure it automatically detects buffer mode
 
-    pipe([from([]), toThrough(readable), concat(assert)], done);
-  });
+      var preContents = ['from', ' ', 'upstream', ' '];
+      var contents = ['hello', ' ', 'world', ' ', '123'];
 
-  it('passes through all upstream before readable', function (done) {
-    var readable = from(contents);
+      it('can wrap a Readable and be used as a Readable', function (done) {
+        var readable = from(contents);
 
-    function assert(result) {
-      expect(result.toString()).toEqual(preContents.concat(contents).join(''));
-    }
+        function assert(result) {
+          expect(result.toString()).toEqual(contents.join(''));
+        }
 
-    pipe([from(preContents), toThrough(readable), concat(assert)], done);
-  });
+        pipeline([toThrough(readable), concat(assert)], done);
+      });
 
-  it('re-emits errors from readable', function (done) {
-    var readable = from([new Error('boom')]);
+      it('can watch data event', function (done) {
+        var to = toThrough(from(contents));
+        var data = [];
 
-    function assert(err) {
-      expect(err.message).toEqual('boom');
-      done();
-    }
+        to.on('data', function (result) {
+          data.push(result);
+        });
 
-    pipe([from(preContents), toThrough(readable), concat()], assert);
-  });
+        to.on('end', function () {
+          expect(data.join('')).toEqual(contents.join(''));
+          done()
+        });
+      });
 
-  it('does not flush the stream if not piped before nextTick', function (done) {
-    var readable = from(contents);
+      it('can wrap a Readable and be used as a Transform', function (done) {
+        var readable = from(contents);
 
-    var wrapped = toThrough(readable);
+        function assert(result) {
+          expect(result.toString()).toEqual(contents.join(''));
+        }
 
-    function assert(result) {
-      expect(result.toString()).toEqual(preContents.concat(contents).join(''));
-    }
+        pipeline([from([]), toThrough(readable), concat(assert)], done);
+      });
 
-    process.nextTick(function () {
-      pipe([from(preContents), wrapped, concat(assert)], done);
+      it('passes through all upstream before readable', function (done) {
+        var readable = from(contents);
+
+        function assert(result) {
+          expect(result.toString()).toEqual(preContents.concat(contents).join(''));
+        }
+
+        pipeline([from(preContents), toThrough(readable), concat(assert)], done);
+      });
+
+      it('re-emits errors from readable', function (done) {
+        var readable = new Readable({
+          read: function () {
+            this.emit('error', new Error('boom'));
+          }
+        });
+
+        function assert(err) {
+          expect(err.message).toEqual('boom');
+          done();
+        }
+
+        pipeline([from(preContents), toThrough(readable), concat()], assert);
+      });
+
+      it('does not flush the stream if not piped before nextTick', function (done) {
+        var readable = from(contents);
+
+        var wrapped = toThrough(readable);
+
+        function assert(result) {
+          expect(result.toString()).toEqual(preContents.concat(contents).join(''));
+        }
+
+        process.nextTick(function () {
+          pipeline([from(preContents), wrapped, concat(assert)], done);
+        });
+      });
     });
-  });
-});
 
-describe('toThrough (object mode)', function () {
-  // These tests ensure it automatically detects objectMode
+    describe('object mode', function () {
+      // These tests ensure it automatically detects objectMode
 
-  var preContents = [{ value: -2 }, { value: -1 }, { value: 0 }];
-  var contents = [
-    { value: 1 },
-    { value: 2 },
-    { value: 3 },
-    { value: 4 },
-    { value: 5 },
-    { value: 6 },
-    { value: 7 },
-    { value: 8 },
-    { value: 9 },
-    { value: 10 },
-    { value: 11 },
-    { value: 12 },
-    { value: 13 },
-    { value: 14 },
-    { value: 15 },
-    { value: 16 },
-    { value: 17 },
-    { value: 18 },
-    { value: 19 },
-    { value: 20 },
-  ];
+      var preContents = [{ value: -2 }, { value: -1 }, { value: 0 }];
+      var contents = [
+        { value: 1 },
+        { value: 2 },
+        { value: 3 },
+        { value: 4 },
+        { value: 5 },
+        { value: 6 },
+        { value: 7 },
+        { value: 8 },
+        { value: 9 },
+        { value: 10 },
+        { value: 11 },
+        { value: 12 },
+        { value: 13 },
+        { value: 14 },
+        { value: 15 },
+        { value: 16 },
+        { value: 17 },
+        { value: 18 },
+        { value: 19 },
+        { value: 20 },
+      ];
 
-  it('can wrap a Readable and be used as a Readable', function (done) {
-    var readable = from.obj(contents);
+      it('can wrap a Readable and be used as a Readable', function (done) {
+        var readable = fromObj(contents, {objectMode: true});
 
-    function assert(result) {
-      expect(result).toEqual(contents);
-    }
+        function assert(result) {
+          expect(result).toEqual(contents);
+        }
 
-    pipe([toThrough(readable), concat(assert)], done);
-  });
+        pipeline([toThrough(readable), concat(assert)], done);
+      });
 
-  it('can wrap a Readable and be used as a Transform', function (done) {
-    var readable = from.obj(contents);
+      it('can wrap a Readable and be used as a Transform', function (done) {
+        var readable = fromObj(contents);
 
-    function assert(result) {
-      expect(result).toEqual(contents);
-    }
+        function assert(result) {
+          expect(result).toEqual(contents);
+        }
 
-    pipe([from.obj([]), toThrough(readable), concat(assert)], done);
-  });
+        pipeline([fromObj([]), toThrough(readable), concat(assert)], done);
+      });
 
-  it('passes through all upstream before readable', function (done) {
-    var readable = from.obj(contents);
+      it('passes through all upstream before readable', function (done) {
+        var readable = fromObj(contents);
 
-    function assert(result) {
-      expect(result).toEqual(preContents.concat(contents));
-    }
+        function assert(result) {
+          expect(result).toEqual(preContents.concat(contents));
+        }
 
-    pipe([from.obj(preContents), toThrough(readable), concat(assert)], done);
-  });
+        pipeline([fromObj(preContents), toThrough(readable), concat(assert)], done);
+      });
 
-  it('does not flush the stream if not piped before nextTick', function (done) {
-    var readable = from.obj(contents);
+      it('does not flush the stream if not piped before nextTick', function (done) {
+        var readable = fromObj(contents);
 
-    var wrapped = toThrough(readable);
+        var wrapped = toThrough(readable);
 
-    function assert(result) {
-      expect(result).toEqual(preContents.concat(contents));
-    }
+        function assert(result) {
+          expect(result).toEqual(preContents.concat(contents));
+        }
 
-    process.nextTick(function () {
-      pipe([from.obj(preContents), wrapped, concat(assert)], done);
+        process.nextTick(function () {
+          pipeline([fromObj(preContents), wrapped, concat(assert)], done);
+        });
+      });
     });
-  });
-});
+  };
+}
+
+describe('stream.pipeline with stream.Readable, concatStream', testRunner(stream.pipeline, stream.Readable, concatStream));
+describe('stream.pipeline with stream.Readable, streamxConcat', testRunner(stream.pipeline, stream.Readable, streamxConcat));
+
+describe('stream.pipeline with streamx.Readable, concatStream', testRunner(stream.pipeline, streamx.Readable, concatStream));
+describe('stream.pipeline with streamx.Readable, streamxConcat', testRunner(stream.pipeline, streamx.Readable, streamxConcat));

--- a/test/index.js
+++ b/test/index.js
@@ -281,7 +281,7 @@ function suite(moduleName) {
     });
 
     it('inherits the highWaterMark of the wrapped stream', function (done) {
-      this.timeout(7000);
+      this.timeout(10000);
 
       var readable = stream.Readable.from(contents, {
         highWaterMark: 1,
@@ -302,7 +302,7 @@ function suite(moduleName) {
     });
 
     it('respects highWaterMark of the output stream', function (done) {
-      this.timeout(7000);
+      this.timeout(10000);
 
       var readable = stream.Readable.from(contents);
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,206 +1,242 @@
 'use strict';
 
 var expect = require('expect');
-var stream = require('readable-stream');
-var streamx = require('streamx');
-var concatStream = require('concat-stream');
 
 var toThrough = require('../');
 
-function streamxConcat(callback) {
-  var results = [];
+function isStringLike(item) {
+  return typeof item === 'string' || Buffer.isBuffer(item);
+}
 
-  return new streamx.Writable({
-    write: function (data, cb) {
-      results.push(data);
-      cb();
-    },
+function suite(moduleName) {
+  var stream = require(moduleName);
 
-    flush: function () {
-      if (callback) {
-        if (results.length > 0 && typeof results[0] === 'string') {
-          results.toString = function () {
-            return results.join('');
-          };
-        }
+  function concat(fn, opts) {
+    var items = [];
 
-        callback(results);
+    return new stream.Writable(
+      Object.assign({}, opts, {
+        write: function (data, enc, cb) {
+          if (typeof enc === 'function') {
+            cb = enc;
+          }
+
+          items.push(data);
+          cb();
+        },
+
+        final: function (cb) {
+          if (typeof fn === 'function') {
+            if (items.every(isStringLike)) {
+              fn(items.join(''));
+            } else {
+              fn(items);
+            }
+          }
+          cb();
+        },
+      })
+    );
+  }
+
+  describe('buffered (' + moduleName + ')', function () {
+    // These tests ensure it automatically detects buffer mode
+
+    var preContents = ['from', ' ', 'upstream', ' '];
+    var contents = ['hello', ' ', 'world', ' ', '123'];
+
+    it('can wrap a Readable and be used as a Readable', function (done) {
+      var readable = stream.Readable.from(contents, { objectMode: false });
+
+      function assert(result) {
+        expect(result).toEqual(contents.join(''));
       }
-    }
+
+      stream.pipeline([toThrough(readable), concat(assert)], done);
+    });
+
+    it('can watch data event', function (done) {
+      var to = toThrough(stream.Readable.from(contents));
+      var data = [];
+
+      to.on('data', function (result) {
+        data.push(result);
+      });
+
+      to.on('end', function () {
+        expect(data.join('')).toEqual(contents.join(''));
+        done();
+      });
+    });
+
+    it('can wrap a Readable and be used as a Transform', function (done) {
+      var readable = stream.Readable.from(contents);
+
+      function assert(result) {
+        expect(result).toEqual(contents.join(''));
+      }
+
+      stream.pipeline(
+        [stream.Readable.from([]), toThrough(readable), concat(assert)],
+        done
+      );
+    });
+
+    it('passes through all upstream before readable', function (done) {
+      var readable = stream.Readable.from(contents);
+
+      function assert(result) {
+        expect(result).toEqual(preContents.concat(contents).join(''));
+      }
+
+      stream.pipeline(
+        [
+          stream.Readable.from(preContents),
+          toThrough(readable),
+          concat(assert),
+        ],
+        done
+      );
+    });
+
+    it('re-emits errors from readable', function (done) {
+      var readable = new stream.Readable({
+        read: function (cb) {
+          var err = new Error('boom');
+          if (typeof cb === 'function') {
+            return cb(err);
+          }
+
+          this.destroy(err);
+        },
+      });
+
+      function assert(err) {
+        expect(err.message).toEqual('boom');
+        done();
+      }
+
+      stream.pipeline(
+        [stream.Readable.from(preContents), toThrough(readable), concat()],
+        assert
+      );
+    });
+
+    it('does not flush the stream if not piped before nextTick', function (done) {
+      var readable = stream.Readable.from(contents);
+
+      var wrapped = toThrough(readable);
+
+      function assert(result) {
+        expect(result).toEqual(preContents.concat(contents).join(''));
+      }
+
+      process.nextTick(function () {
+        stream.pipeline(
+          [stream.Readable.from(preContents), wrapped, concat(assert)],
+          done
+        );
+      });
+    });
+  });
+
+  describe('object mode (' + moduleName + ')', function () {
+    // These tests ensure it automatically detects objectMode
+
+    var preContents = [{ value: -2 }, { value: -1 }, { value: 0 }];
+    var contents = [
+      { value: 1 },
+      { value: 2 },
+      { value: 3 },
+      { value: 4 },
+      { value: 5 },
+      { value: 6 },
+      { value: 7 },
+      { value: 8 },
+      { value: 9 },
+      { value: 10 },
+      { value: 11 },
+      { value: 12 },
+      { value: 13 },
+      { value: 14 },
+      { value: 15 },
+      { value: 16 },
+      { value: 17 },
+      { value: 18 },
+      { value: 19 },
+      { value: 20 },
+    ];
+
+    it('can wrap a Readable and be used as a Readable', function (done) {
+      var readable = stream.Readable.from(contents);
+
+      function assert(result) {
+        expect(result).toEqual(contents);
+      }
+
+      stream.pipeline(
+        [toThrough(readable), concat(assert, { objectMode: true })],
+        done
+      );
+    });
+
+    it('can wrap a Readable and be used as a Transform', function (done) {
+      var readable = stream.Readable.from(contents);
+
+      function assert(result) {
+        expect(result).toEqual(contents);
+      }
+
+      stream.pipeline(
+        [
+          stream.Readable.from([]),
+          toThrough(readable),
+          concat(assert, { objectMode: true }),
+        ],
+        done
+      );
+    });
+
+    it('passes through all upstream before readable', function (done) {
+      var readable = stream.Readable.from(contents);
+
+      function assert(result) {
+        expect(result).toEqual(preContents.concat(contents));
+      }
+
+      stream.pipeline(
+        [
+          stream.Readable.from(preContents),
+          toThrough(readable),
+          concat(assert, { objectMode: true }),
+        ],
+        done
+      );
+    });
+
+    it('does not flush the stream if not piped before nextTick', function (done) {
+      var readable = stream.Readable.from(contents);
+
+      var wrapped = toThrough(readable);
+
+      function assert(result) {
+        expect(result).toEqual(preContents.concat(contents));
+      }
+
+      process.nextTick(function () {
+        stream.pipeline(
+          [
+            stream.Readable.from(preContents),
+            wrapped,
+            concat(assert, { objectMode: true }),
+          ],
+          done
+        );
+      });
+    });
   });
 }
 
-function testRunner (pipeline, Readable, concat) {
-  var from = Readable.from;
-  var fromObj = function (contents) {
-    return from(contents, {objectMode: true});
-  };
-
-  return function () {
-    describe('buffered', function () {
-      // These tests ensure it automatically detects buffer mode
-
-      var preContents = ['from', ' ', 'upstream', ' '];
-      var contents = ['hello', ' ', 'world', ' ', '123'];
-
-      it('can wrap a Readable and be used as a Readable', function (done) {
-        var readable = from(contents);
-
-        function assert(result) {
-          expect(result.toString()).toEqual(contents.join(''));
-        }
-
-        pipeline([toThrough(readable), concat(assert)], done);
-      });
-
-      it('can watch data event', function (done) {
-        var to = toThrough(from(contents));
-        var data = [];
-
-        to.on('data', function (result) {
-          data.push(result);
-        });
-
-        to.on('end', function () {
-          expect(data.join('')).toEqual(contents.join(''));
-          done()
-        });
-      });
-
-      it('can wrap a Readable and be used as a Transform', function (done) {
-        var readable = from(contents);
-
-        function assert(result) {
-          expect(result.toString()).toEqual(contents.join(''));
-        }
-
-        pipeline([from([]), toThrough(readable), concat(assert)], done);
-      });
-
-      it('passes through all upstream before readable', function (done) {
-        var readable = from(contents);
-
-        function assert(result) {
-          expect(result.toString()).toEqual(preContents.concat(contents).join(''));
-        }
-
-        pipeline([from(preContents), toThrough(readable), concat(assert)], done);
-      });
-
-      it('re-emits errors from readable', function (done) {
-        var readable = new Readable({
-          read: function () {
-            this.emit('error', new Error('boom'));
-          }
-        });
-
-        function assert(err) {
-          expect(err.message).toEqual('boom');
-          done();
-        }
-
-        pipeline([from(preContents), toThrough(readable), concat()], assert);
-      });
-
-      it('does not flush the stream if not piped before nextTick', function (done) {
-        var readable = from(contents);
-
-        var wrapped = toThrough(readable);
-
-        function assert(result) {
-          expect(result.toString()).toEqual(preContents.concat(contents).join(''));
-        }
-
-        process.nextTick(function () {
-          pipeline([from(preContents), wrapped, concat(assert)], done);
-        });
-      });
-    });
-
-    describe('object mode', function () {
-      // These tests ensure it automatically detects objectMode
-
-      var preContents = [{ value: -2 }, { value: -1 }, { value: 0 }];
-      var contents = [
-        { value: 1 },
-        { value: 2 },
-        { value: 3 },
-        { value: 4 },
-        { value: 5 },
-        { value: 6 },
-        { value: 7 },
-        { value: 8 },
-        { value: 9 },
-        { value: 10 },
-        { value: 11 },
-        { value: 12 },
-        { value: 13 },
-        { value: 14 },
-        { value: 15 },
-        { value: 16 },
-        { value: 17 },
-        { value: 18 },
-        { value: 19 },
-        { value: 20 },
-      ];
-
-      it('can wrap a Readable and be used as a Readable', function (done) {
-        var readable = fromObj(contents, {objectMode: true});
-
-        function assert(result) {
-          expect(result).toEqual(contents);
-        }
-
-        pipeline([toThrough(readable), concat(assert)], done);
-      });
-
-      it('can wrap a Readable and be used as a Transform', function (done) {
-        var readable = fromObj(contents);
-
-        function assert(result) {
-          expect(result).toEqual(contents);
-        }
-
-        pipeline([fromObj([]), toThrough(readable), concat(assert)], done);
-      });
-
-      it('passes through all upstream before readable', function (done) {
-        var readable = fromObj(contents);
-
-        function assert(result) {
-          expect(result).toEqual(preContents.concat(contents));
-        }
-
-        pipeline([fromObj(preContents), toThrough(readable), concat(assert)], done);
-      });
-
-      it('does not flush the stream if not piped before nextTick', function (done) {
-        var readable = fromObj(contents);
-
-        var wrapped = toThrough(readable);
-
-        function assert(result) {
-          expect(result).toEqual(preContents.concat(contents));
-        }
-
-        process.nextTick(function () {
-          pipeline([fromObj(preContents), wrapped, concat(assert)], done);
-        });
-      });
-    });
-  };
-}
-
-describe('stream.pipeline with stream.Readable, concatStream', testRunner(stream.pipeline, stream.Readable, concatStream));
-describe('stream.pipeline with stream.Readable, streamxConcat', testRunner(stream.pipeline, stream.Readable, streamxConcat));
-
-describe('stream.pipeline with streamx.Readable, concatStream', testRunner(stream.pipeline, streamx.Readable, concatStream));
-describe('stream.pipeline with streamx.Readable, streamxConcat', testRunner(stream.pipeline, streamx.Readable, streamxConcat));
-
-/* Disabled until streamx.pipeline callback is working
-describe('streamx.pipeline with stream.Readable, concatStream', testRunner(streamx.pipeline, stream.Readable, concatStream));
-describe('streamx.pipeline with stream.Readable, streamxConcat', testRunner(streamx.pipeline, stream.Readable, streamxConcat));
-
-describe('streamx.pipeline with streamx.Readable, concatStream', testRunner(streamx.pipeline, streamx.Readable, concatStream));
-describe('streamx.pipeline with streamx.Readable, streamxConcat', testRunner(streamx.pipeline, streamx.Readable, streamxConcat));
- */
+suite('stream');
+suite('streamx');
+suite('readable-stream');

--- a/test/index.js
+++ b/test/index.js
@@ -204,6 +204,19 @@ function suite(moduleName) {
         );
       });
     });
+
+    it('destroys the readable if the wrapper is destroyed', function (done) {
+      var readable = stream.Readable.from(contents, { objectMode: false });
+
+      var wrapped = toThrough(readable);
+
+      readable.on('error', function (err) {
+        expect(err.message).toEqual('Wrapper destroyed');
+        done();
+      });
+
+      wrapped.destroy();
+    });
   });
 
   describe('object mode (' + moduleName + ')', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,7 @@ function suite(moduleName) {
     var contents = ['hello', ' ', 'world', ' ', '123'];
 
     it('can wrap a Readable and be used as a Readable', function (done) {
-      var readable = stream.Readable.from(contents, { objectMode: false });
+      var readable = stream.Readable.from(contents);
 
       function assert(result) {
         expect(result).toEqual(contents.join(''));

--- a/test/index.js
+++ b/test/index.js
@@ -227,6 +227,10 @@ function suite(moduleName) {
         expect(wrapped.destroyed).toEqual(true);
         done();
       });
+      readable.on('error', function (err) {
+        // To ensure another error isn't surfaced
+        expect(err).toBeUndefined();
+      });
 
       readable.destroy();
     });


### PR DESCRIPTION
I feel like this should not be merged yet.  All tests currently use `require('stream').pipeline`, I'd like to expand this to also cover using `require('streamx').pipeline` but this is currently broken.